### PR TITLE
Open documentation links in a new window

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
             jQuery('#show_green').click(function(e) {
                 jQuery('#log').toggleClass('no_green');
             });
+            // Links with rel="external" open a new window
+            jQuery('body').on('click', 'a[href][rel~="external"]', function(e) {
+              window.open(this.href, '', '');
+              e.preventDefault();
+            });
         });
         var run = function () {
           var host = jQuery('#es_host').val();

--- a/js/logger.js
+++ b/js/logger.js
@@ -55,7 +55,7 @@ function Logger(out_id) {
   function result(color, check, msg, docs) {
     check = check.replace(/`([^`]+)`/g, "<code>$1</code>");
     if (docs) {
-      docs = '<a class="info fa" title="Read more" href="' + docs + '"></a>';
+      docs = '<a class="info fa" title="Read more" href="' + docs + '" rel="external"></a>';
     } else {
       docs = '';
     }


### PR DESCRIPTION
To ease reading back and forth the plugin checks and the documentation, I think it's better to have the links open in a new window.

To make this unobtrusive, I've added a snippet of javascript to open links with `rel="external"` in a new window.
